### PR TITLE
Added badge count to repo nav buttons to reflect number of issues.

### DIFF
--- a/src/components/Repo/index.js
+++ b/src/components/Repo/index.js
@@ -1,9 +1,10 @@
 import React from 'react';
 
-const Repo = ({ repo, changeRepo, repoPath }) => (
+const Repo = ({ repo, changeRepo, repoPath, repoIssues }) => (
   <div className="repoSwitches">
     <button className="btn btn-subnav" onClick={() => changeRepo(repoPath)}>
       {repo}
+      <span className="badge">{repoIssues}</span>
     </button>
   </div>
   );
@@ -11,11 +12,13 @@ const Repo = ({ repo, changeRepo, repoPath }) => (
 Repo.propTypes = {
   repo: React.PropTypes.string.isRequired,
   repoPath: React.PropTypes.string,
+  repoIssues: React.PropTypes.number,
   changeRepo: React.PropTypes.func.isRequired,
 };
 
 Repo.defaultProps = {
   repo: {},
   repoPath: '',
+  repoIssues: 0,
 };
 export default Repo;

--- a/src/components/ReposList/index.js
+++ b/src/components/ReposList/index.js
@@ -8,6 +8,7 @@ const ReposList = ({ repos, changeRepo }) => (
         key={repo.path}
         repo={repo.name}
         repoPath={repo.path}
+        repoIssues={repo.open_issues_count}
         changeRepo={changeRepo}
       />,
       )}

--- a/src/css/components/_buttons.sass
+++ b/src/css/components/_buttons.sass
@@ -26,3 +26,13 @@
     background-color: $pink
     color: $white
     border: 3px solid $pink
+    span
+      &.badge
+        background-color: $white
+        color: $pink
+  span
+    &.badge
+      background-color: $pink
+      border-radius: 1rem
+      margin-left: 0.8em
+      padding: 0.3em 0.5em


### PR DESCRIPTION
Fixes issue #61 

Looks like the `open_issues_count` also includes PRs in it's total. Assuming this is ok.

<img width="813" alt="repo-btn-badge" src="https://cloud.githubusercontent.com/assets/8689444/26268812/bb53219e-3cb6-11e7-8773-6fdaade2c7fd.png">
